### PR TITLE
Add task_session migration

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,12 +31,20 @@ fn app_startup(app: &mut tauri::App) -> Result<(), Box<dyn Error>> {
 fn main() {
     let state_flags = StateFlags::all() - StateFlags::VISIBLE;
 
-    let migrations = vec![Migration {
-        version: 1,
-        description: "Initial migration",
-        sql: include_str!("./migrations/000_initial.sql"),
-        kind: MigrationKind::Up,
-    }];
+    let migrations = vec![
+        Migration {
+            version: 1,
+            description: "Initial migration",
+            sql: include_str!("./migrations/000_initial.sql"),
+            kind: MigrationKind::Up,
+        },
+        Migration {
+            version: 2,
+            description: "Task session table",
+            sql: include_str!("./migrations/001_task_session.sql"),
+            kind: MigrationKind::Up,
+        },
+    ];
 
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::new().build())

--- a/src-tauri/src/migrations/001_task_session.sql
+++ b/src-tauri/src/migrations/001_task_session.sql
@@ -1,0 +1,13 @@
+CREATE TABLE task_session (
+  -- 自動増分の主キー
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- 関連するタスクID、NULL不可
+  task_id INTEGER NOT NULL,
+  -- 休憩かどうか、0=false 1=true
+  is_break INTEGER NOT NULL DEFAULT 0,
+  -- セッション時間（秒）、NULL不可
+  duration INTEGER NOT NULL,
+  -- 完了日時、デフォルトは現在時刻
+  completed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(task_id) REFERENCES task(id)
+);


### PR DESCRIPTION
## Summary
- add migration script for `task_session`
- register the new migration in `main.rs`

## Testing
- `npm run lint` *(fails: Code style issues found)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861b1a990c0832b8d4ab7bcf69e70f3